### PR TITLE
Avoid verbose build logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def setup_python3():
     from os.path import join
 
     tmp_src = join("build", "src")
-    log.set_verbosity(1)
+    # log.set_verbosity(1)
     fl = FileList()
     for line in open("MANIFEST.in"):
         if not line.strip():


### PR DESCRIPTION
For systems that install many packages, very verbose logging for a particular package is a pain when tracking down build errors from other packages.