### PR TITLE
Packaging and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,7 @@ before_script:
 
 script:
     - nosetests
+
+matrix:
+  allow_failures:
+    - python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,28 +5,19 @@ branches:
   only:
     - master
 python:
-    - "2.6"
-    - "2.7"
-      #- "3.2"
-    - "3.3"
-
-before_install:
-    # Travis has too old setuptools for html5lib. Please remove this when a fix
-    # for html5lib or rdflib is released.
-    - pip install -U setuptools pip
+    - 2.7
+    - 3.3
+    - 3.4
+    - 3.5
+    - 3.6
+    - pypy
+    - pypy3
 
 install:
-    # iodate0.4.8 is problematic with Pypy, use fixed version
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.5' ]]; then pip install --use-mirrors "simplejson==2.0.9"; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then pip install --upgrade "https://bitbucket.org/gjhiggins/isodate/downloads/isodate-0.4.8.tar.gz"; fi
-    - pip install -r requirements.travis.txt
-    - python setup.py install
+    - pip install . nose flake8
 
 before_script:
-    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '2' ]]; then flake8 --exclude=test --exit-zero rdflib_jsonld; fi
+    - flake8 --exit-zero rdflib_jsonld
+
 script:
-    # Must run the tests in build/src so python3 doesn't get confused and run
-    # the python2 code from the current directory instead of the installed
-    # 2to3 version in build/src.
-    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '2' ]]; then nosetests; fi
-    - if [[ ${TRAVIS_PYTHON_VERSION%%.*} == '3' ]]; then nosetests --where=./build/src; fi
+    - nosetests

--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
-RDFLib plugin providing JSON-LD parsing and serialization
-=========================================================
+# RDFLib plugin providing JSON-LD parsing and serialization
 
-This is an implementation of [JSON-LD](http://www.w3.org/TR/json-ld/) for [RDFLib](https://github.com/RDFLib/rdflib). For more information about this technology, see the [JSON-LD website](http://json-ld.org/).
+This is an implementation of [JSON-LD](http://www.w3.org/TR/json-ld/)
+for [RDFLib](https://github.com/RDFLib/rdflib).
+For more information about this technology, see the [JSON-LD website](http://json-ld.org/).
 
 This implementation will:
 
-* read in an JSON-LD formatted document and create an RDF graph
-* serialize an RDF graph to JSON-LD formatted output
+- read in an JSON-LD formatted document and create an RDF graph
+- serialize an RDF graph to JSON-LD formatted output
 
 
-Installation
-------------
+## Installation
 
 The easiest way to install the RDFLib JSON-LD plugin is directly from PyPi using pip by running the command below:
 
-    pip install rdflib-jsonld
+```shell
+pip install rdflib-jsonld
+```
 
 Otherwise you can download the source and install it directly by running:
 
-    python setup.py install
+```shell
+python setup.py install
+```
 
 
-Using the plug-in JSONLD serializer/parser with RDFLib
-------------------------------------------------------
+## Using the plug-in JSONLD serializer/parser with RDFLib
 
 The plugin parser and serializer are automatically registered if installed by
 setuptools.
-    
+
 ```python
 >>> from rdflib import Graph, plugin
 >>> from rdflib.serializer import Serializer
@@ -63,17 +66,17 @@ setuptools.
 ```
 
 
-Building the Sphinx documentation
----------------------------------
+## Building the Sphinx documentation
 
-If Sphinx is installed, Sphinx documentation can be generated with::
+If Sphinx is installed, Sphinx documentation can be generated with:
 
-    $ python setup.py build_sphinx
+```shell
+$ python setup.py build_sphinx
+```
 
 The documentation will be created in ./build/sphinx.
 
 
-Continuous integration tests
-----------------------------
+## Continuous integration tests
 
 [![Build Status](https://travis-ci.org/RDFLib/rdflib-jsonld.png?branch=master)](https://travis-ci.org/RDFLib/rdflib-jsonld)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ setuptools.
 }
 ```
 
+<!-- CUT HERE -->
+<!-- Text after this comment won't appear on PyPI -->
 
 ## Building the Sphinx documentation
 
@@ -79,4 +81,4 @@ The documentation will be created in ./build/sphinx.
 
 ## Continuous integration tests
 
-[![Build Status](https://travis-ci.org/RDFLib/rdflib-jsonld.png?branch=master)](https://travis-ci.org/RDFLib/rdflib-jsonld)
+[![Build Status](https://travis-ci.org/RDFLib/rdflib-jsonld.svg?branch=master)](https://travis-ci.org/RDFLib/rdflib-jsonld)

--- a/docs/jsonld-parser.rst
+++ b/docs/jsonld-parser.rst
@@ -40,9 +40,9 @@ manipulate the resulting graph.
 Module contents
 ---------------
 
-.. currentmodule:: rdflib_jsonld.jsonld_parser
+.. currentmodule:: rdflib_jsonld.parser
 
-.. automodule:: rdflib_jsonld.jsonld_parser
+.. automodule:: rdflib_jsonld.parser
 
 .. autoclass:: JsonLDParser
    :members: parse

--- a/docs/jsonld-serializer.rst
+++ b/docs/jsonld-serializer.rst
@@ -41,9 +41,9 @@ Read in an RDFLib Graph and serialize it, specifying ``format='json-ld'``.
 Module contents
 ---------------
 
-.. currentmodule:: rdflib_jsonld.jsonld_serializer
+.. currentmodule:: rdflib_jsonld.serializer
 
 .. autoclass:: JsonLDSerializer
    :members: serialize
 
-.. autofunction:: to_tree
+.. autofunction:: from_rdf

--- a/rdflib_jsonld/_compat.py
+++ b/rdflib_jsonld/_compat.py
@@ -1,0 +1,6 @@
+import sys
+
+IS_PY3 = sys.version_info[0] >= 3
+
+basestring = str if IS_PY3 else basestring  # noqa
+unicode = str if IS_PY3 else unicode  # noqa

--- a/rdflib_jsonld/context.py
+++ b/rdflib_jsonld/context.py
@@ -8,6 +8,7 @@ Implementation of the JSON-LD Context structure. See:
 from collections import namedtuple
 from rdflib.namespace import RDF
 
+from ._compat import basestring, unicode
 from .keys import (BASE, CONTAINER, CONTEXT, GRAPH, ID, INDEX, LANG, LIST,
         REV, SET, TYPE, VALUE, VOCAB)
 from . import errors

--- a/rdflib_jsonld/parser.py
+++ b/rdflib_jsonld/parser.py
@@ -40,6 +40,7 @@ from rdflib.parser import Parser, URLInputSource
 from rdflib.namespace import RDF, XSD
 from rdflib.term import URIRef, BNode, Literal
 
+from ._compat import basestring, unicode
 from .context import Context, Term, UNDEF
 from .util import source_to_json, VOCAB_DELIMS, context_from_urlinputsource
 from .keys import CONTEXT, GRAPH, ID, INDEX, LANG, LIST, REV, SET, TYPE, VALUE, VOCAB

--- a/rdflib_jsonld/serializer.py
+++ b/rdflib_jsonld/serializer.py
@@ -45,6 +45,7 @@ from rdflib.graph import Graph
 from rdflib.term import URIRef, Literal, BNode
 from rdflib.namespace import RDF, XSD
 
+from ._compat import unicode
 from .context import Context, UNDEF
 from .util import json
 from .keys import CONTEXT, GRAPH, ID, VOCAB, LIST, SET, LANG
@@ -180,7 +181,7 @@ class Converter(object):
                     and not any(graph.subjects(None, s))):
                 self.process_subject(graph, s, nodemap)
 
-        return nodemap.values()
+        return list(nodemap.values())
 
     def process_subject(self, graph, s, nodemap):
         if isinstance(s, URIRef):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,7 @@
 [nosetests]
-
 attr=!known_issue
 verbosity=1
 with-doctest=1
 
-
-
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,100 +1,113 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import sys
+from __future__ import unicode_literals
+
+import io
 import re
 
-# Ridiculous as it may seem, we need to import multiprocessing and logging here
-# in order to get tests to pass smoothly on python 2.7.
-try:
-    import multiprocessing
-    import logging
-except:
-    pass
+from os.path import dirname
+from setuptools import setup
+
+ROOT = dirname(__file__)
+
+RE_REQUIREMENT = re.compile(r'^\s*-r\s*(?P<filename>.*)$')
+
+RE_MD_CODE_BLOCK = re.compile(r'```(?P<language>\w+)?\n(?P<lines>.*?)```', re.S)
+RE_SELF_LINK = re.compile(r'\[(.*?)\]\[\]')
+RE_LINK_TO_URL = re.compile(r'\[(?P<text>.*?)\]\((?P<url>.*?)\)')
+RE_LINK_TO_REF = re.compile(r'\[(?P<text>.*?)\]\[(?P<ref>.*?)\]')
+RE_LINK_REF = re.compile(r'^\[(?P<key>[^!].*?)\]:\s*(?P<url>.*)$', re.M)
+RE_BADGE = re.compile(r'^\[\!\[(?P<text>.*?)\]\[(?P<badge>.*?)\]\]\[(?P<target>.*?)\]$', re.M)
+RE_TITLE = re.compile(r'^(?P<level>#+)\s*(?P<title>.*)$', re.M)
+
+RST_TITLE_LEVELS = ['=', '-', '*']
 
 
-def setup_python3():
-    # Taken from "distribute" setup.py
-    from distutils.filelist import FileList
-    from distutils import dir_util, file_util, util, log
-    from os.path import join
+def md2pypi(filename):
+    '''
+    Load .md (markdown) file and sanitize it for PyPI.
+    Remove unsupported github tags:
+     - code-block directive
+     - travis ci build badges
+    '''
+    content = io.open(filename).read()
 
-    tmp_src = join("build", "src")
-    # log.set_verbosity(1)
-    fl = FileList()
-    for line in open("MANIFEST.in"):
-        if not line.strip():
-            continue
-        fl.process_template_line(line)
-    dir_util.create_tree(tmp_src, fl.files)
-    outfiles_2to3 = []
-    for f in fl.files:
-        outf, copied = file_util.copy_file(f, join(tmp_src, f), update=1)
-        if copied and outf.endswith(".py"):
-            outfiles_2to3.append(outf)
+    for match in RE_MD_CODE_BLOCK.finditer(content):
+        rst_block = '\n'.join(
+            ['.. code-block:: {language}'.format(**match.groupdict()), ''] +
+            ['    {0}'.format(l) for l in match.group('lines').split('\n')] +
+            ['']
+        )
+        content = content.replace(match.group(0), rst_block)
 
-    util.run_2to3(outfiles_2to3)
+    refs = dict(RE_LINK_REF.findall(content))
+    content = RE_LINK_REF.sub('.. _\g<key>: \g<url>', content)
+    content = RE_SELF_LINK.sub('`\g<1>`_', content)
+    content = RE_LINK_TO_URL.sub('`\g<text> <\g<url>>`_', content)
 
-    # arrange setup to use the copy
-    sys.path.insert(0, tmp_src)
+    for match in RE_BADGE.finditer(content):
+        content = content.replace(match.group(0), '')
 
-    return tmp_src
+    # Must occur after badges
+    for match in RE_LINK_TO_REF.finditer(content):
+        content = content.replace(match.group(0), '`{text} <{url}>`_'.format(
+            text=match.group('text'),
+            url=refs[match.group('ref')]
+        ))
+
+    for match in RE_TITLE.finditer(content):
+        underchar = RST_TITLE_LEVELS[len(match.group('level')) - 1]
+        title = match.group('title')
+        underline = underchar * len(title)
+
+        full_title = '\n'.join((title, underline))
+        content = content.replace(match.group(0), full_title)
+
+    return content
 
 
-# Find version. We have to do this because we can't import it in Python 3 until
-# its been automatically converted in the setup process.
-def find_version(filename):
-    _version_re = re.compile(r'__version__ = "(.*)"')
-    for line in open(filename):
-        version_match = _version_re.match(line)
-        if version_match:
-            return version_match.group(1)
+name = 'rdflib-jsonld'
+version = __import__('rdflib_jsonld').__version__
 
-__version__ = find_version('rdflib_jsonld/__init__.py')
 
-install_requires = ["rdflib>=4.0", ] 
-
-if sys.version_info[:2] < (2, 6):
-    install_requires += ["simplejson"]
-
-config = dict(
-    name = 'rdflib-jsonld',
-    description = "rdflib extension adding JSON-LD parser and serializer",
-    maintainer = "RDFLib Team",
-    maintainer_email = "http://groups.google.com/group/rdflib-dev",
-    url = "https://github.com/RDFLib/rdflib-jsonld",
-    version = __version__,
-    download_url = "https://github.com/RDFLib/rdflib-jsonld/zipball/master",
-    license = "BSD",
-    platforms = ["any"],
-    long_description = \
-    """
-    This parser/serialiser will
-
-    * read in an JSON-LD formatted document and create an RDF graph
-    * serialize an RDF graph to JSON-LD formatted output
-
-    See:
-
-        http://json-ld.org/
-    """,
-    classifiers = [
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.5",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
-        "License :: OSI Approved :: BSD License",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Operating System :: OS Independent",
-        "Natural Language :: English",
-                   ],
-    packages = ["rdflib_jsonld"],
-    test_suite = "test",
-    install_requires = ["rdflib>=4.2"],
-    entry_points = {
+setup(
+    name=name,
+    version=version,
+    description='rdflib extension adding JSON-LD parser and serializer',
+    long_description=md2pypi('README.md'),
+    maintainer='RDFLib Team',
+    maintainer_email='http://groups.google.com/group/rdflib-dev',
+    url='https://github.com/RDFLib/rdflib-jsonld',
+    license='BSD',
+    packages=['rdflib_jsonld'],
+    use_2to3=True,
+    zip_safe=False,
+    platforms=['any'],
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'License :: OSI Approved :: BSD License',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Operating System :: OS Independent',
+        'Natural Language :: English',
+    ],
+    test_suite='nose.collector',
+    install_requires=['rdflib>=4.2'],
+    tests_require=['nose'],
+    command_options={
+        'build_sphinx': {
+            'project': ('setup.py', name),
+            'version': ('setup.py', '.'.join(version.split('.')[:2])),
+            'release': ('setup.py', version)
+        }
+    },
+    entry_points={
         'rdf.plugins.parser': [
             'json-ld = rdflib_jsonld.parser:JsonLDParser',
             'application/ld+json = rdflib_jsonld.parser:JsonLDParser',
@@ -105,17 +118,3 @@ config = dict(
         ],
     }
 )
-
-if sys.version_info[0] >= 3:
-    from setuptools import setup
-    config.update({'use_2to3': True})
-    config.update({'src_root': setup_python3()})
-else:
-    try:
-        from setuptools import setup
-        config.update({'test_suite' : "nose.collector"})
-    except ImportError:
-        from distutils.core import setup
-
-
-setup(**config)

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ RE_SELF_LINK = re.compile(r'\[(.*?)\]\[\]')
 RE_LINK_TO_URL = re.compile(r'\[(?P<text>.*?)\]\((?P<url>.*?)\)')
 RE_LINK_TO_REF = re.compile(r'\[(?P<text>.*?)\]\[(?P<ref>.*?)\]')
 RE_LINK_REF = re.compile(r'^\[(?P<key>[^!].*?)\]:\s*(?P<url>.*)$', re.M)
-RE_BADGE = re.compile(r'^\[\!\[(?P<text>.*?)\]\[(?P<badge>.*?)\]\]\[(?P<target>.*?)\]$', re.M)
 RE_TITLE = re.compile(r'^(?P<level>#+)\s*(?P<title>.*)$', re.M)
+CUT = '<!-- CUT HERE -->'
 
 RST_TITLE_LEVELS = ['=', '-', '*']
 
@@ -27,10 +27,9 @@ def md2pypi(filename):
     '''
     Load .md (markdown) file and sanitize it for PyPI.
     Remove unsupported github tags:
-     - code-block directive
      - travis ci build badges
     '''
-    content = io.open(filename).read()
+    content = io.open(filename).read().split(CUT)[0]
 
     for match in RE_MD_CODE_BLOCK.finditer(content):
         rst_block = '\n'.join(
@@ -45,10 +44,6 @@ def md2pypi(filename):
     content = RE_SELF_LINK.sub('`\g<1>`_', content)
     content = RE_LINK_TO_URL.sub('`\g<text> <\g<url>>`_', content)
 
-    for match in RE_BADGE.finditer(content):
-        content = content.replace(match.group(0), '')
-
-    # Must occur after badges
     for match in RE_LINK_TO_REF.finditer(content):
         content = content.replace(match.group(0), '`{text} <{url}>`_'.format(
             text=match.group('text'),

--- a/test/test_compaction.py
+++ b/test/test_compaction.py
@@ -234,7 +234,7 @@ def run(data, expected):
     sort_graph(result)
     result = json.dumps(result, **json_kwargs)
     incr = itertools.count(1)
-    result = re.sub(r'"_:[^"]+"', lambda m: '"_:blank-%s"' % incr.next(), result)
+    result = re.sub(r'"_:[^"]+"', lambda m: '"_:blank-%s"' % next(incr), result)
 
     sort_graph(expected)
     expected = json.dumps(expected, **json_kwargs)

--- a/test/test_named_graphs.py
+++ b/test/test_named_graphs.py
@@ -52,4 +52,4 @@ def test_dataset():
     contexts = dict((ctx.identifier, ctx) for ctx in ds.contexts())
     assert len(contexts) == 2
     assert len(contexts.pop(meta_ctx)) == 1
-    assert len(contexts.values()[0]) == 2
+    assert len(list(contexts.values())[0]) == 2

--- a/tox.ini
+++ b/tox.ini
@@ -1,67 +1,20 @@
 [tox]
-envlist = 
-    py25,py26,py27,py32,py33,cover,pypy#,jython
+envlist =
+    py{27,33,34,35,36,py,py3},cover
 
 [testenv]
-commands = 
-    {envpython} setup.py clean --all
-    {envpython} setup.py build
-    nosetests
+commands = nosetests
 deps =
     nose
-    git+https://github.com/RDFLib/rdflib#egg=rdflib
-
-[testenv:py25]
-basepython =
-    python2.5
-commands = 
-    {envpython} setup.py clean --all
-    {envpython} setup.py build
-    nosetests
-deps =
-    nose
-    git+https://github.com/RDFLib/rdflib#egg=rdflib
-    simplejson==2.0.9
-
-[testenv:jython]
-commands = 
-    jython setup.py clean --all
-    jython setup.py build
-    nosetests
-deps =
-    nose
-    git+https://github.com/RDFLib/rdflib#egg=rdflib
-    simplejson
-
-[testenv:py32]
-basepython = python3.2
-commands = 
-    {envpython} setup.py clean --all
-    {envpython} setup.py build
-    nosetests -q --where=./build/src
-deps =
-    nose
-    git+https://github.com/RDFLib/rdflib#egg=rdflib
-
-[testenv:py33]
-basepython = python3.3
-commands = 
-    {envpython} setup.py clean --all
-    {envpython} setup.py build
-    nosetests -q --where=./build/src
-deps =
-    nose
-    git+https://github.com/RDFLib/rdflib#egg=rdflib
 
 [testenv:cover]
 basepython = python2.7
-commands = 
+commands =
     nosetests --with-coverage --cover-html --cover-html-dir=./coverage \
                  --cover-package=rdflib_jsonld --cover-inclusive
 deps =
     nose
     coverage
-    git+https://github.com/RDFLib/rdflib#egg=rdflib
 
 # we separate coverage into its own testenv because a) "last run wins" wrt
 # cobertura jenkins reporting and b) pypy and jython can't handle any


### PR DESCRIPTION
This pull-request fix/simplify packaging by:
- using the standard `use_2to3` option
- exposing proper compatibility, ie. same as rdflib (removed python 2.6 and added python 3.6)
- Reuse readme.md as long description
- removed the deprecated `download_url`
- simply import version from module
- use universal wheel

It also fix the documentation:
- fixes references to modules/package
- configure setuptools integration to use provided version and name

Also fix testing:
- test against published versions (tox)
- use nose collector setuptools integration and declare test dependencies
- simplify `tox` configuration and make use of default behavior
- simplify TravisCI configuration

At last but not least, it fixes Python 3 support (`unicode`, `basestring` and iterator handling`)

This should simplify the contributing process
