### PR TITLE
PY3 and format_doctest_out fixes for compatibility with rdflib 5.0 br…

### DIFF
--- a/rdflib_jsonld/util.py
+++ b/rdflib_jsonld/util.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     import simplejson as json
 
-from rdflib.py3compat import PY3, format_doctest_out
+from six import PY3
 
 from os import sep
 from os.path import normpath
@@ -41,7 +41,6 @@ def split_iri(iri):
             return iri[:at+1], iri[at+1:]
     return iri, None
 
-@format_doctest_out
 def norm_url(base, url):
     """
     >>> norm_url('http://example.org/', '/one')

--- a/test/test_testsuite.py
+++ b/test/test_testsuite.py
@@ -7,7 +7,7 @@ except ImportError:
     import simplejson as json
 from rdflib import ConjunctiveGraph, Graph, Literal, URIRef
 from rdflib.compare import isomorphic
-from rdflib.py3compat import PY3
+from six import PY3
 import rdflib_jsonld.parser
 from rdflib_jsonld.parser import to_rdf
 from rdflib_jsonld.serializer import from_rdf

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,33,34,35,36,py,py3},cover
+    py{27,33,34,35,36,37,py,py3},cover
 
 [testenv]
 commands = nosetests


### PR DESCRIPTION
We need to use the rdflib 5.0.0 branch AND rdflib-jsonld.  This fixes an issue with the missing py3compat module