### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,17 @@ branches:
     - master
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
+    - 3.8
     - pypy
     - pypy3
+
+arch:
+    - amd64
+    - ppc64le
 
 install:
     - pip install . nose flake8
@@ -25,3 +30,8 @@ script:
 matrix:
   allow_failures:
     - python: pypy3
+  exclude:
+    - arch: ppc64le
+      python: pypy
+    - arch: ppc64le
+      python: pypy3


### PR DESCRIPTION
Added latest python versions and power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.