### PR TITLE
Drop use_2to3 and restore rdflib interoperability

### DIFF
--- a/rdflib_jsonld/serializer.py
+++ b/rdflib_jsonld/serializer.py
@@ -10,6 +10,7 @@ Example usage::
     >>> register('json-ld', Serializer, 'rdflib_jsonld.serializer', 'JsonLDSerializer')
 
     >>> from rdflib import Graph
+    >>> from rdflib import __version__ as rdflib_version
 
     >>> testrdf = '''
     ... @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -19,7 +20,12 @@ Example usage::
 
     >>> g = Graph().parse(data=testrdf, format='n3')
 
-    >>> print(g.serialize(format='json-ld', indent=4))
+    >>> g_display = g.serialize(format='json-ld', indent=4)
+    >>> if rdflib_version < "6.0.0":
+    ...     # rdflib < 6.0.0 returns bytes when no
+    ...     # destination is provided.
+    ...     g_display = g_display.decode()
+    >>> print(g_display)
     [
         {
             "@id": "http://example.org/about",

--- a/rdflib_jsonld/serializer.py
+++ b/rdflib_jsonld/serializer.py
@@ -19,7 +19,7 @@ Example usage::
 
     >>> g = Graph().parse(data=testrdf, format='n3')
 
-    >>> print(g.serialize(format='json-ld', indent=4).decode())
+    >>> print(g.serialize(format='json-ld', indent=4))
     [
         {
             "@id": "http://example.org/about",

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ setup(
     url="https://github.com/RDFLib/rdflib-jsonld",
     license="BSD",
     packages=["rdflib_jsonld"],
-    use_2to3=True,
     zip_safe=False,
     platforms=["any"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         "Natural Language :: English",
     ],
     test_suite="nose.collector",
-    install_requires=["rdflib>=5.0.0"],
+    install_requires=["rdflib<6.0.0"],
     tests_require=["nose"],
     command_options={
         "build_sphinx": {

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "Natural Language :: English",
     ],
     test_suite="nose.collector",
-    install_requires=["rdflib<6.0.0"],
+    install_requires=["rdflib"],
     tests_require=["nose"],
     command_options={
         "build_sphinx": {

--- a/test/runner.py
+++ b/test/runner.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 import json
+import rdflib
 from rdflib import ConjunctiveGraph
 from rdflib.compare import isomorphic
 from rdflib_jsonld._compat import IS_PY3
@@ -9,7 +10,12 @@ from rdflib_jsonld.keys import CONTEXT, GRAPH
 
 
 # monkey-patch NTriplesParser to keep source bnode id:s ..
-from rdflib.plugins.parsers.ntriples import NTriplesParser, r_nodeid, bNode
+from rdflib.plugins.parsers.ntriples import r_nodeid, bNode
+# NTriplesParser was renamed between 5.0.0 and 6.0.0.
+if rdflib.__version__ < "6":
+    from rdflib.plugins.parsers.ntriples import NTriplesParser
+else:
+    from rdflib.plugins.parsers.ntriples import W3CNTriplesParser as NTriplesParser
 
 
 def _preserving_nodeid(self):

--- a/test/runner.py
+++ b/test/runner.py
@@ -18,11 +18,17 @@ else:
     from rdflib.plugins.parsers.ntriples import W3CNTriplesParser as NTriplesParser
 
 
-def _preserving_nodeid(self):
-    if not self.peek("_"):
-        return False
-    return bNode(self.eat(r_nodeid).group(1))
-
+# NTriplesParser.nodeid changed its function signature between 5.0.0 and 6.0.0.
+if rdflib.__version__ < "6":
+    def _preserving_nodeid(self):
+        if not self.peek("_"):
+            return False
+        return bNode(self.eat(r_nodeid).group(1))
+else:
+    def _preserving_nodeid(self, bnode_context=None):
+        if not self.peek("_"):
+            return False
+        return bNode(self.eat(r_nodeid).group(1))
 
 NTriplesParser.nodeid = _preserving_nodeid
 # .. and accept bnodes everywhere

--- a/test/test_compaction.py
+++ b/test/test_compaction.py
@@ -233,7 +233,9 @@ json_kwargs = dict(indent=2, separators=(",", ": "), sort_keys=True, ensure_asci
 
 def run(data, expected):
     g = Graph().parse(data=data, format="turtle")
-    result = g.serialize(format="json-ld", context=expected["@context"]).decode("utf-8")
+    result = g.serialize(format="json-ld", context=expected["@context"])
+    if isinstance(result, bytes):
+        result = result.decode("utf-8")
     result = json.loads(result)
 
     sort_graph(result)


### PR DESCRIPTION
This patch series has two goals:

1. Remove the `use_2to3` flag from `setup.py`, as setuptools#2770 set
   that flag to trigger an error.  (Further discussion might ensue on
   setuptools#2779.)
2. Perform minimal upgrades to have unit tests pass equally well to the
   state archived in July, whether rdflib 5.0.0 or 6.0.0 is present.
   (NOTE - it appears to me that unit tests do not pass in the July
   state, and this is noted in the first patch, which establishes the
   testing baseline. The end effect of this patch series leaves no new
   known failures.)

Together, these will make `rdflib-jsonld` continue to be a transparent
import, aiding users that did not realize, or cannot accommodate, that
the package had been integrated into rdflib.

More pragmatically, downstream builds depending on rdflib-jsonld should
no longer halt on reaching this dependency.

How to socialize the package being deprecated is left for a separate
patch series.

Tests were run with the following script, commenting out some portions
when fail states were expected:

```bash
#!/bin/bash

# This software was developed at the National Institute of Standards
# and Technology by employees of the Federal Government in the course
# of their official duties. Pursuant to title 17 Section 105 of the
# United States Code this software is not subject to copyright
# protection and is in the public domain. NIST assumes no
# responsibility whatsoever for its use by other parties, and makes
# no guarantees, expressed or implied, about its quality,
# reliability, or any other characteristic.
#
# We would appreciate acknowledgement if the software is used.

set -x
set -e
set -u

if [ ! -d venv0 ]; then
  python3 -m venv venv0
  source venv0/bin/activate
    pip install nose
    pip install rdflib==5.0.0
    pip install --editable .
  deactivate
fi

if [ ! -d venv1 ]; then
  python3 -m venv venv1
  source venv1/bin/activate
    pip install --upgrade setuptools nose
    pip install rdflib==5.0.0
    pip install --editable .
  deactivate
fi

if [ ! -d venv2 ]; then
  python3 -m venv venv2
  source venv2/bin/activate
    pip install nose
    pip install rdflib==6.0.0
    pip install --editable .
  deactivate
fi

if [ ! -d venv3 ]; then
  python3 -m venv venv3
  source venv3/bin/activate
    pip install --upgrade setuptools nose
    pip install rdflib==6.0.0
    pip install --editable .
  deactivate
fi

for x in 0 1 2 3 ; do
  source venv${x}/bin/activate
    nosetests || true
  deactivate
done
```

References:
* https://github.com/RDFLib/rdflib/issues/1405
* https://github.com/pypa/setuptools/issues/2769
* https://github.com/pypa/setuptools/issues/2770

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>