### PR TITLE
Restore pin to rdflib >= 5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "Natural Language :: English",
     ],
     test_suite="nose.collector",
-    install_requires=["rdflib"],
+    install_requires=["rdflib>=5.0.0"],
     tests_require=["nose"],
     command_options={
         "build_sphinx": {


### PR DESCRIPTION
This was accidentally removed as part of this pull request:
https://github.com/RDFLib/rdflib-jsonld/pull/105

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>